### PR TITLE
updated to support libE 0.9.0 and newer

### DIFF
--- a/vtmop/test_vtmop.py
+++ b/vtmop/test_vtmop.py
@@ -40,6 +40,10 @@ num_objs = 3
 lower = 0.0
 upper = 1.0
 
+# Set up the problem
+nworkers, is_manager, libE_specs, _ = parse_args()
+lower_bounds = lower * np.ones(num_dims)
+upper_bounds = upper * np.ones(num_dims)
 
 # Definition of the sum function
 def sim_f(H, *unused):
@@ -52,18 +56,13 @@ def sim_f(H, *unused):
     Out['f'] = f
     return Out, {}
 
-
-# Set up the problem
-nworkers, is_manager, libE_specs, _ = parse_args()
-lower_bounds = lower * np.ones(num_dims)
-upper_bounds = upper * np.ones(num_dims)
-
 # Set up the simulator
 sim_specs = {
     'sim_f': sim_f,
     'in': ['x'],
     'out': [('f', float, num_objs)],
 }
+
 
 # Set up the generator
 gen_specs = {
@@ -110,113 +109,115 @@ gen_specs = {
 # Set up the allocator
 alloc_specs = {'alloc_f': alloc_f, 'out': []}
 
-s1 = []
-H = []
+if __name__ == "__main__":
+ 
+    s1 = []
+    H = []
 
-for run in range(3):
-    if run == 0:
-        # Run for 1100 evaluations or 300 seconds
-        H0 = None
-        exit_criteria = {'sim_max': 1100, 'elapsed_wallclock_time': 300}
-
-    elif run == 1:
-        # In the second run, we initialize VTMOP with an initial sample of previously evaluated points
-        np.random.seed(0)
-        size = 1000
-
-        # Generate the sample
-        X = np.random.uniform(gen_specs['user']['lb'], gen_specs['user']['ub'], (size, num_dims))
-        f = np.zeros((size, num_objs))
-
-        # Initialize H0
-        H0_dtype = [
-            ('x', float, num_dims),
-            ('f', float, num_objs),
-            ('sim_id', int),
-            ('returned', bool),
-            ('given', bool),
-        ]
-        H0 = np.zeros(size, dtype=H0_dtype)
-        H0['x'] = X
-        H0['sim_id'] = range(size)
-        H0[['given', 'returned']] = True
-
-        # Perform objective function evaluations
-        for i in range(size):
-            Out, _ = sim_f(H0[[i]])
-            H0['f'][i] = Out['f']
-
-        # Run for 200 more evaluations or 300 seconds
-        exit_criteria = {'sim_max': 200, 'elapsed_wallclock_time': 300}
-
-        gen_specs['user']['isnb'] = 0
-        gen_specs['user']['new_run'] = True  # Need to set this as it can be overwritten within the libE call.
-
-    elif run == 2:
-        # In the third run, we restart VTMOP by loading in the history array saved in run==1
-        gen_specs['user']['new_run'] = False
-        gen_specs['user']['lopt_budget'] = 3000
-        gen_specs['user']['decay'] = 0.1
-        gen_specs['user']['des_tol'] = 1e-16
-        gen_specs['user']['eps'] = 1e-16
-        gen_specs['user']['epsw'] = 1e-16
-        gen_specs['user']['obj_tol'] = 1e-16
-        gen_specs['user'].pop('trust_radf')
-        gen_specs['user']['min_radf'] = 1e-16
-        gen_specs['user']['pmode'] = True
-        gen_specs['user']['obj_bounds'] = np.full((1, num_objs), -np.inf)
-
-        # Inelegant way to have the manager copy over the VTMOP checkpoint
-        # file, and have every worker get the H value from the run==1 case to
-        # use in the restart.
-        try:
-            os.remove('manager_done_file')
-        except OSError:
-            pass
-
+    for run in range(3):
+        if run == 0:
+            # Run for 1100 evaluations or 300 seconds
+            H0 = None
+            exit_criteria = {'sim_max': 1100, 'wallclock_max': 300}
+    
+        elif run == 1:
+            # In the second run, we initialize VTMOP with an initial sample of previously evaluated points
+            np.random.seed(0)
+            size = 1000
+    
+            # Generate the sample
+            X = np.random.uniform(gen_specs['user']['lb'], gen_specs['user']['ub'], (size, num_dims))
+            f = np.zeros((size, num_objs))
+    
+            # Initialize H0
+            H0_dtype = [
+                ('x', float, num_dims),
+                ('f', float, num_objs),
+                ('sim_id', int),
+                ('sim_ended', bool),
+                ('sim_started', bool),
+            ]
+            H0 = np.zeros(size, dtype=H0_dtype)
+            H0['x'] = X
+            H0['sim_id'] = range(size)
+            H0[['sim_started', 'sim_ended']] = True
+    
+            # Perform objective function evaluations
+            for i in range(size):
+                Out, _ = sim_f(H0[[i]])
+                H0['f'][i] = Out['f']
+    
+            # Run for 200 more evaluations or 300 seconds
+            exit_criteria = {'sim_max': 200, 'wallclock_max': 300}
+    
+            gen_specs['user']['isnb'] = 0
+            gen_specs['user']['new_run'] = True  # Need to set this as it can be overwritten within the libE call.
+    
+        elif run == 2:
+            # In the third run, we restart VTMOP by loading in the history array saved in run==1
+            gen_specs['user']['new_run'] = False
+            gen_specs['user']['lopt_budget'] = 3000
+            gen_specs['user']['decay'] = 0.1
+            gen_specs['user']['des_tol'] = 1e-16
+            gen_specs['user']['eps'] = 1e-16
+            gen_specs['user']['epsw'] = 1e-16
+            gen_specs['user']['obj_tol'] = 1e-16
+            gen_specs['user'].pop('trust_radf')
+            gen_specs['user']['min_radf'] = 1e-16
+            gen_specs['user']['pmode'] = True
+            gen_specs['user']['obj_bounds'] = np.full((1, num_objs), -np.inf)
+    
+            # Inelegant way to have the manager copy over the VTMOP checkpoint
+            # file, and have every worker get the H value from the run==1 case to
+            # use in the restart.
+            try:
+                os.remove('manager_done_file')
+            except OSError:
+                pass
+    
+            if is_manager:
+                os.rename('vtmop.chkpt_finishing_' + s1, 'vtmop.chkpt')
+                np.save('H_for_vtmop_restart.npy', H)
+                open('manager_done_file', 'w').close()
+            else:
+                while not os.path.isfile('manager_done_file'):
+                    time.sleep(0.1)
+                H = np.load('H_for_vtmop_restart.npy')
+    
+            # Initialize H0 with values from H (from the run==1 case)
+            size = sum(H['sim_ended'])
+            H0_dtype = [
+                ('x', float, num_dims),
+                ('f', float, num_objs),
+                ('sim_id', int),
+                ('sim_ended', bool),
+                ('sim_started', bool),
+            ]
+            H0 = np.zeros(size, dtype=H0_dtype)
+            H0['x'] = H['x'][:size]
+            H0['sim_id'] = range(size)
+            H0[['sim_started', 'sim_ended']] = True
+            H0['f'] = H['f'][:size]
+    
+            # Run for 200 more evaluations or 300 seconds
+            exit_criteria = {'sim_max': 200, 'wallclock_max': 300}
+    
+        # Persistent info between iterations
+        persis_info = add_unique_random_streams({}, nworkers + 1)
+        persis_info['next_to_give'] = 0 if H0 is None else len(H0)
+        persis_info['total_gen_calls'] = 0
+    
+        # Perform the run
+        H, persis_info, flag = libE(
+            sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs, H0=H0
+        )
+    
+        # The manager takes care of checkpointing/output
         if is_manager:
-            os.rename('vtmop.chkpt_finishing_' + s1, 'vtmop.chkpt')
-            np.save('H_for_vtmop_restart.npy', H)
-            open('manager_done_file', 'w').close()
-        else:
-            while not os.path.isfile('manager_done_file'):
-                time.sleep(0.1)
-            H = np.load('H_for_vtmop_restart.npy')
-
-        # Initialize H0 with values from H (from the run==1 case)
-        size = sum(H['returned'])
-        H0_dtype = [
-            ('x', float, num_dims),
-            ('f', float, num_objs),
-            ('sim_id', int),
-            ('returned', bool),
-            ('given', bool),
-        ]
-        H0 = np.zeros(size, dtype=H0_dtype)
-        H0['x'] = H['x'][:size]
-        H0['sim_id'] = range(size)
-        H0[['given', 'returned']] = True
-        H0['f'] = H['f'][:size]
-
-        # Run for 200 more evaluations or 300 seconds
-        exit_criteria = {'sim_max': 200, 'elapsed_wallclock_time': 300}
-
-    # Persistent info between iterations
-    persis_info = add_unique_random_streams({}, nworkers + 1)
-    persis_info['next_to_give'] = 0 if H0 is None else len(H0)
-    persis_info['total_gen_calls'] = 0
-
-    # Perform the run
-    H, persis_info, flag = libE(
-        sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs, H0=H0
-    )
-
-    # The manager takes care of checkpointing/output
-    if is_manager:
-        # Renaming vtmop checkpointing file, if needed for later use.
-        timer.start()
-        s1 = timer.date_start.replace(' ', '_')
-        os.rename('vtmop.chkpt', 'vtmop.chkpt_finishing_' + s1)
-
-        assert flag == 0
-        save_libE_output(H, persis_info, __file__, nworkers)
+            # Renaming vtmop checkpointing file, if needed for later use.
+            timer.start()
+            s1 = timer.date_start.replace(' ', '_')
+            os.rename('vtmop.chkpt', 'vtmop.chkpt_finishing_' + s1)
+    
+            assert flag == 0
+            save_libE_output(H, persis_info, __file__, nworkers)

--- a/vtmop/vtmop.py
+++ b/vtmop/vtmop.py
@@ -159,7 +159,7 @@ def vtmop_gen(H, persis_info, gen_specs, _):
 
          H0['sim_id'] (np.ndarray): Set H0['sim_id'] = range(n).
 
-         H0[['given', 'returned']] = True
+         H0[['sim_started', 'sim_ended']] = True
 
      A checkpoint file (``vtmop.chkpt``) will be generated in the calling
      directory to save the status of VTMOP, and can be used to recover in


### PR DESCRIPTION
Fixed some of the interfacing-breaking changes from libE 0.9.0 upgrade in the ``test_vtmop.py`` script.

It now runs with latest version of libE, but I still get the following warning.  Please advise if it is serious:

```
[0]  2023-06-28 14:27:18,539 libensemble.history (MANAGER_WARNING): Giving entries in H0 back to gen. Marking entries in H0 as 'gen_informed' if 'sim_ended'.
```