### PR TITLE
Refactor/cnn gen on cpu or gpu

### DIFF
--- a/gen_updates_cnn/gen_updates_cnn/simulator.py
+++ b/gen_updates_cnn/gen_updates_cnn/simulator.py
@@ -68,7 +68,7 @@ def model_trainer(InitialData, _, sim_specs, info):
     user = sim_specs["user"]
 
     store = _connect_to_store(user["proxystore_hostname"])
-    device = _get_device(info, sim_specs)
+    device = _get_device(info, sim_specs, is_generator=False)
 
     generator = ToGenerator(info, EVAL_SIM_TAG)
     workerID = info["workerID"]

--- a/gen_updates_cnn/gen_updates_cnn/utils.py
+++ b/gen_updates_cnn/gen_updates_cnn/utils.py
@@ -26,12 +26,18 @@ def _get_device(info, specs, is_generator=False):
         else:  # use GPU N for simulator N
             device_id = (worker_id % num_nodes) + 1
         device = torch.device("cuda:" + str(device_id))
-    elif torch.backends.mps.is_available() and specs["user"]["parent_model_device"] == "GPU":
-        device = torch.device("mps")
+    elif torch.backends.mps.is_available():
+        if not is_generator:  # use CPU for simulator
+            device = torch.device("mps")
+        elif specs["user"]["parent_model_device"] == "CPU":  # use CPU for generator
+            device = torch.device("cpu")
+        else:
+            device = torch.device("mps")
     else:
         device = torch.device("cpu")
     if is_generator and specs["user"]["parent_model_device"] == "CPU":  # overwrite device if specified
         device = torch.device("cpu")
+    print("I'm a generator" if is_generator else "I'm a simulator", "and I'm on", device)
     return device
 
 

--- a/gen_updates_cnn/gen_updates_cnn/utils.py
+++ b/gen_updates_cnn/gen_updates_cnn/utils.py
@@ -26,9 +26,11 @@ def _get_device(info, specs, is_generator=False):
         else:  # use GPU N for simulator N
             device_id = (worker_id % num_nodes) + 1
         device = torch.device("cuda:" + str(device_id))
-    elif torch.backends.mps.is_available():
+    elif torch.backends.mps.is_available() and specs["user"]["parent_model_device"] == "GPU":
         device = torch.device("mps")
     else:
+        device = torch.device("cpu")
+    if is_generator and specs["user"]["parent_model_device"] == "CPU":  # overwrite device if specified
         device = torch.device("cpu")
     return device
 

--- a/gen_updates_cnn/pixi.lock
+++ b/gen_updates_cnn/pixi.lock
@@ -291,6 +291,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d4/75/00a852275ade58d3dc474530f7a7b6bc999a817148f0eb59d4fde12eb955/torchvision-0.20.1-cp312-cp312-manylinux1_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/78/eb/65f5ba83c2a123f6498a3097746607e5b2f16add29e36765305e4ac7fdd8/triton-3.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/93/fee9d92dedb7d6d4401578c3aea690463e841cd548c2c2d563c6815499de/wat-0.5.1-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
@@ -392,6 +393,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/57/6c/bf52ff061da33deb9f94f4121fde7ff3058812cb7d2036c97bc167793bd1/torch-2.5.1-cp312-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/eb/4ba19616378f2bc085999432fded2b7dfdbdccc6dd0fc293203452508100/torchvision-0.20.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/93/fee9d92dedb7d6d4401578c3aea690463e841cd548c2c2d563c6815499de/wat-0.5.1-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -2462,6 +2464,11 @@ packages:
   - pysocks>=1.5.6,!=1.5.7,<2.0 ; extra == 'socks'
   - zstandard>=0.18.0 ; extra == 'zstd'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/20/93/fee9d92dedb7d6d4401578c3aea690463e841cd548c2c2d563c6815499de/wat-0.5.1-py3-none-any.whl
+  name: wat
+  version: 0.5.1
+  sha256: a21fdc236cf549e869da0f3c1b945816da50348b3adb07524c4d134ac80168a9
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
   sha256: f21e63e8f7346f9074fd00ca3b079bd3d2fa4d71f1f89d5b6934bf31446dc2a5
   md5: b68980f2495d096e71c7fd9d7ccf63e6

--- a/gen_updates_cnn/pixi.toml
+++ b/gen_updates_cnn/pixi.toml
@@ -24,3 +24,6 @@ dev = ["dev"]
 [feature.dev.dependencies]
 ipdb = ">=0.13.13,<0.14"
 black = ">=24.10.0,<25"
+
+[feature.dev.pypi-dependencies]
+wat = ">=0.5.1, <0.6"

--- a/gen_updates_cnn/run_libe_cnn.py
+++ b/gen_updates_cnn/run_libe_cnn.py
@@ -48,6 +48,7 @@ transform = transforms.Compose(
 dataset1 = datasets.MNIST("../data", train=True, download=True, transform=transform)
 dataset2 = datasets.MNIST("../data", train=False, transform=transform)
 
+PARENT_MODEL_DEVICE = "GPU"  # "CPU"
 MAX_OPTIMIZER_STEPS = 100
 STREAMING_DATABASE_HOST = "localhost"
 NUM_CUDA_NODES = 2
@@ -61,6 +62,7 @@ settings = {
     "max_epochs": 2,
     "proxystore_hostname": STREAMING_DATABASE_HOST,
     "num_nodes": NUM_CUDA_NODES,
+    "parent_model_device": PARENT_MODEL_DEVICE,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
There doesn't appear to be a substantial difference, at least locally.

```
(gen_updates_cnn:dev) jnavarro@CSI0362818:/Users/jnavarro/Desktop/libensemble/libe-community-examples/gen_updates_cnn git:(refactor/cnn_gen_on_cpu_or_gpu*) $ for i in {1..10}; do
  time python run_libe_cnn.py -n 2 
done | awk '{sum+=$2} END {print sum/10}'
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  15.33s user 7.26s system 97% cpu 23.198 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.19s user 5.56s system 94% cpu 20.808 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.22s user 5.31s system 95% cpu 20.393 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  15.17s user 6.43s system 97% cpu 22.264 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.09s user 5.50s system 95% cpu 20.592 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.51s user 5.24s system 97% cpu 20.308 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.89s user 6.78s system 95% cpu 22.659 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.80s user 5.44s system 98% cpu 20.634 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.38s user 5.98s system 95% cpu 21.314 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  15.65s user 8.08s system 87% cpu 27.078 total
# Swap GPU to CPU for gen
(gen_updates_cnn:dev) jnavarro@CSI0362818:/Users/jnavarro/Desktop/libensemble/libe-community-examples/gen_updates_cnn git:(refactor/cnn_gen_on_cpu_or_gpu*) $ for i in {1..10}; do
  time python run_libe_cnn.py -n 2
done | awk '{sum+=$2} END {print sum/10}'
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  15.08s user 6.76s system 97% cpu 22.435 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.52s user 5.20s system 99% cpu 19.887 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.21s user 5.69s system 98% cpu 20.126 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.14s user 5.45s system 97% cpu 20.145 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.34s user 5.07s system 100% cpu 19.312 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.23s user 5.53s system 98% cpu 20.062 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.81s user 5.41s system 96% cpu 20.933 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.85s user 5.38s system 100% cpu 20.212 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.09s user 5.22s system 99% cpu 19.485 total
------------------ Run completed -------------------
Saving results to file: ./run_libe_cnn_history_length=100_evals=100_workers=2
python run_libe_cnn.py -n 2  14.97s user 7.14s system 96% cpu 22.830 total
```